### PR TITLE
Add exception handling for calculate button

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,7 @@
 #include <QtWidgets/QGridLayout>
 #include <QtWidgets/QStatusBar>
 #include <QtCore/QDebug>
+#include <stdexcept>
 
 // Function to handle errors by printing the error message to the debug output
 void handleError(QString message) {
@@ -91,8 +92,12 @@ int main(int argc, char *argv[]) {
     // Handle the equal button
     QObject::connect(buttonCalculate, &QPushButton::clicked, [&]() {
         myCalculator.setSecondOperand(myCalculator.getCurrentInput().toDouble());
-        double result = myCalculator.calculateResult();
-        inputDisplay.setText(QString::number(result));
+        try {
+            double result = myCalculator.calculateResult();
+            inputDisplay.setText(QString::number(result));
+        } catch (const std::logic_error &e) {
+            handleError(QString::fromStdString(e.what()));
+        }
         myCalculator.clear();
     });
 

--- a/test.cpp
+++ b/test.cpp
@@ -41,16 +41,25 @@ void test() {
         handleError("Division test failed.");
     }
 
-    // Test division by zero
+    // Test division by zero and recovery
     calc.setFirstOperand(20);
     calc.setSecondOperand(0);
     calc.setOperator('/');
     try {
         result = calc.calculateResult();
+        handleError("Division by zero test failed.");
     } catch (const std::logic_error& e) {
         handleError("Division by zero test passed: " + QString::fromStdString(e.what()));
     } catch (...) {
         handleError("Division by zero test failed.");
+    }
+    calc.clear();
+    calc.setFirstOperand(1);
+    calc.setSecondOperand(1);
+    calc.setOperator('+');
+    result = calc.calculateResult();
+    if (result != 2) {
+        handleError("Calculator not cleared after division by zero.");
     }
 
     qDebug() << "All tests passed.";


### PR DESCRIPTION
## Summary
- handle `std::logic_error` in the `=` button lambda
- include `<stdexcept>` for exception class
- extend division by zero test to clear state and verify recovery

## Testing
- `qmake && make -j$(nproc)` *(fails: qmake not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843f54c5d8c8324b8b46eb729ed752d