### PR TITLE
Add Qt CI workflow

### DIFF
--- a/.github/workflows/qt.yml
+++ b/.github/workflows/qt.yml
@@ -1,0 +1,28 @@
+name: Qt CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v3
+        with:
+          version: '5.15.2'
+          setup-python: 'false'
+      - name: Build
+        run: |
+          qmake calculator.pro
+          make
+      - name: Test
+        run: |
+          qmake tests.pro
+          make
+          make check
+        env:
+          QT_QPA_PLATFORM: offscreen
+


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build and test the Qt app

## Testing
- `qmake tests.pro && make -j$(nproc) && QT_QPA_PLATFORM=offscreen make check`

------
https://chatgpt.com/codex/tasks/task_b_6843f7dc54cc8324969118193e842108