### PR TITLE
Add decimal point support

### DIFF
--- a/calculator.cpp
+++ b/calculator.cpp
@@ -80,6 +80,17 @@ void Calculator::setDigit(int digit) {
     m_currentInput.append(QString::number(digit));
 }
 
+// Function to append a decimal point to the current input if not already present
+void Calculator::setDecimalPoint() {
+    if (!m_currentInput.contains('.')) {
+        if (m_currentInput.isEmpty()) {
+            m_currentInput.append("0.");
+        } else {
+            m_currentInput.append('.');
+        }
+    }
+}
+
 // Function to set the addition operator and store the first operand
 void Calculator::setOperatorAdd() {
     setFirstOperand(m_currentInput.toDouble());

--- a/calculator.h
+++ b/calculator.h
@@ -34,6 +34,7 @@ public:
 public slots:
     // Slot functions for handling user input
     void setDigit(int digit);
+    void setDecimalPoint();
     void setOperatorAdd();
     void setOperatorSubtract();
     void setOperatorMultiply();

--- a/main.cpp
+++ b/main.cpp
@@ -53,8 +53,10 @@ int main(int argc, char *argv[]) {
 
     // Create clear and calculate buttons
     QPushButton *buttonClear = new QPushButton("C");
+    QPushButton *buttonDecimal = new QPushButton(".");
     QPushButton *buttonCalculate = new QPushButton("=");
-    buttonLayout.addWidget(buttonClear, 4, 0);
+    buttonLayout.addWidget(buttonClear, 0, 1);
+    buttonLayout.addWidget(buttonDecimal, 4, 0);
     buttonLayout.addWidget(buttonCalculate, 4, 2);
 
     // Add layouts to the main layout
@@ -66,6 +68,7 @@ int main(int argc, char *argv[]) {
         QPushButton *digitButton = buttonLayout.findChild<QPushButton *>(QString("button%1").arg(i));
         QObject::connect(digitButton, &QPushButton::clicked, &myCalculator, [&, i] { myCalculator.setDigit(i); });
     }
+    QObject::connect(buttonDecimal, &QPushButton::clicked, &myCalculator, &Calculator::setDecimalPoint);
 
     QObject::connect(buttonAdd, &QPushButton::clicked, &myCalculator, &Calculator::setOperatorAdd);
     QObject::connect(buttonSubtract, &QPushButton::clicked, &myCalculator, &Calculator::setOperatorSubtract);
@@ -79,6 +82,7 @@ int main(int argc, char *argv[]) {
         QPushButton *digitButton = buttonLayout.findChild<QPushButton *>(QString("button%1").arg(i));
         QObject::connect(digitButton, &QPushButton::clicked, updateDisplayLambda);
     }
+    QObject::connect(buttonDecimal, &QPushButton::clicked, updateDisplayLambda);
 
     QObject::connect(buttonAdd, &QPushButton::clicked, updateDisplayLambda);
     QObject::connect(buttonSubtract, &QPushButton::clicked, updateDisplayLambda);

--- a/tests/tst_calculator.cpp
+++ b/tests/tst_calculator.cpp
@@ -11,6 +11,7 @@ private slots:
     void division();
     void divisionByZero();
     void clearAfterError();
+    void decimalAddition();
 };
 
 void CalculatorTest::addition()
@@ -74,6 +75,15 @@ void CalculatorTest::clearAfterError()
     calc.setSecondOperand(1);
     calc.setOperator('+');
     QCOMPARE(calc.calculateResult(), 2.0);
+}
+
+void CalculatorTest::decimalAddition()
+{
+    Calculator calc;
+    calc.setFirstOperand(2.5);
+    calc.setSecondOperand(0.5);
+    calc.setOperator('+');
+    QCOMPARE(calc.calculateResult(), 3.0);
 }
 
 QTEST_MAIN(CalculatorTest)


### PR DESCRIPTION
## Summary
- add decimal point handling slot in Calculator
- connect new decimal button in UI layout
- rearrange Clear button
- add test for decimal addition

## Testing
- `qmake tests.pro && make -j$(nproc)`
- `QT_QPA_PLATFORM=offscreen ./calculator_test -maxwarnings 0`


------
https://chatgpt.com/codex/tasks/task_b_6843f88467a48324843ff6759355b427