### PR TITLE
Add clang-format and update docs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+BreakBeforeBraces: Attach
+ColumnLimit: 120
+AllowShortIfStatementsOnASingleLine: true

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ qmake tests.pro
 make
 make check    # or run ./calculator_test manually
 ```
+
+### Code Style
+
+The project defines its formatting rules in a `.clang-format` file. Run
+
+```bash
+clang-format -i <file>
+```
+
+on source files before committing changes to ensure a consistent style.
 ## License
 
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- set up `.clang-format` for consistent code style
- document clang-format usage in README

## Testing
- `qmake tests.pro`
- `make`
- `QT_QPA_PLATFORM=offscreen ./calculator_test`

------
https://chatgpt.com/codex/tasks/task_b_6843fa6ba34c83249ccc1646ca4309aa