### PR TITLE
Document headless test env

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ qmake tests.pro
 make
 make check    # or run ./calculator_test manually
 ```
+If the system does not provide a display server, set `QT_QPA_PLATFORM=offscreen`
+when running the tests:
+
+```bash
+QT_QPA_PLATFORM=offscreen make check
+```
 ## License
 
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- document that tests can run without a display server
- show how to run tests with `QT_QPA_PLATFORM=offscreen`

## Testing
- `qmake tests.pro`
- `make -j$(nproc)`
- `QT_QPA_PLATFORM=offscreen make check`

------
https://chatgpt.com/codex/tasks/task_b_6843fa666d408324b0b3f24dd2bc422f