### PR TITLE
Ignore Qt build outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ ui_*.h
 *.user
 *.qrc
 *.rcc
+
+# Application binaries
+calculator
+calculator_test


### PR DESCRIPTION
## Summary
- ignore the application binary `calculator`
- ignore the test binary `calculator_test`

## Testing
- `qmake --version`
- `qmake tests.pro`
- `make`
- `make check` *(fails: could not connect to display)*

------
https://chatgpt.com/codex/tasks/task_b_6843fa60a8348324af4786172ba75373