### PR TITLE
Use heap allocation for calculator layouts

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,17 +1,15 @@
 #include "calculator.h"
 
 #include <QtWidgets/QApplication>
-#include <QtWidgets/QPushButton>
-#include <QtWidgets/QLineEdit>
-#include <QtWidgets/QVBoxLayout>
 #include <QtWidgets/QGridLayout>
+#include <QtWidgets/QLineEdit>
 #include <QtWidgets/QMessageBox>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QVBoxLayout>
 #include <stdexcept>
 
 // Function to handle errors by displaying a message box
-void handleError(const QString &message, QWidget *parent = nullptr) {
-    QMessageBox::critical(parent, "Error", message);
-}
+void handleError(const QString &message, QWidget *parent = nullptr) { QMessageBox::critical(parent, "Error", message); }
 
 // Function to update the display of the calculator with the current input
 void updateDisplay(QLineEdit &inputDisplay, const Calculator &myCalculator) {
@@ -21,12 +19,11 @@ void updateDisplay(QLineEdit &inputDisplay, const Calculator &myCalculator) {
 int main(int argc, char *argv[]) {
     QApplication app(argc, argv);
 
-
     Calculator myCalculator;
     QWidget mainWindow;
-    QVBoxLayout mainLayout;
-    QLineEdit inputDisplay;
-    QGridLayout buttonLayout;
+    QVBoxLayout *mainLayout = new QVBoxLayout(&mainWindow);
+    QLineEdit *inputDisplay = new QLineEdit(&mainWindow);
+    QGridLayout *buttonLayout = new QGridLayout(&mainWindow);
 
     // Create digit buttons
     for (int i = 0; i <= 9; ++i) {
@@ -38,7 +35,7 @@ int main(int argc, char *argv[]) {
             row = 4;
             col = 1;
         }
-        buttonLayout.addWidget(digitButton, row, col);
+        buttonLayout->addWidget(digitButton, row, col);
     }
 
     // Create operator buttons
@@ -46,26 +43,26 @@ int main(int argc, char *argv[]) {
     QPushButton *buttonSubtract = new QPushButton("-");
     QPushButton *buttonMultiply = new QPushButton("*");
     QPushButton *buttonDivide = new QPushButton("/");
-    buttonLayout.addWidget(buttonAdd, 1, 3);
-    buttonLayout.addWidget(buttonSubtract, 2, 3);
-    buttonLayout.addWidget(buttonMultiply, 3, 3);
-    buttonLayout.addWidget(buttonDivide, 4, 3);
+    buttonLayout->addWidget(buttonAdd, 1, 3);
+    buttonLayout->addWidget(buttonSubtract, 2, 3);
+    buttonLayout->addWidget(buttonMultiply, 3, 3);
+    buttonLayout->addWidget(buttonDivide, 4, 3);
 
     // Create clear and calculate buttons
     QPushButton *buttonClear = new QPushButton("C");
     QPushButton *buttonDecimal = new QPushButton(".");
     QPushButton *buttonCalculate = new QPushButton("=");
-    buttonLayout.addWidget(buttonClear, 0, 1);
-    buttonLayout.addWidget(buttonDecimal, 4, 0);
-    buttonLayout.addWidget(buttonCalculate, 4, 2);
+    buttonLayout->addWidget(buttonClear, 0, 1);
+    buttonLayout->addWidget(buttonDecimal, 4, 0);
+    buttonLayout->addWidget(buttonCalculate, 4, 2);
 
     // Add layouts to the main layout
-    mainLayout.addWidget(&inputDisplay);
-    mainLayout.addLayout(&buttonLayout);
+    mainLayout->addWidget(inputDisplay);
+    mainLayout->addLayout(buttonLayout);
 
     // Connect the buttons to the corresponding slots
     for (int i = 0; i <= 9; ++i) {
-        QPushButton *digitButton = buttonLayout.findChild<QPushButton *>(QString("button%1").arg(i));
+        QPushButton *digitButton = buttonLayout->findChild<QPushButton *>(QString("button%1").arg(i));
         QObject::connect(digitButton, &QPushButton::clicked, &myCalculator, [&, i] { myCalculator.setDigit(i); });
     }
     QObject::connect(buttonDecimal, &QPushButton::clicked, &myCalculator, &Calculator::setDecimalPoint);
@@ -76,10 +73,10 @@ int main(int argc, char *argv[]) {
     QObject::connect(buttonDivide, &QPushButton::clicked, &myCalculator, &Calculator::setOperatorDivide);
 
     // Connect the buttons to update the display
-    auto updateDisplayLambda = [&]() { updateDisplay(inputDisplay, myCalculator); };
+    auto updateDisplayLambda = [&]() { updateDisplay(*inputDisplay, myCalculator); };
 
     for (int i = 0; i <= 9; ++i) {
-        QPushButton *digitButton = buttonLayout.findChild<QPushButton *>(QString("button%1").arg(i));
+        QPushButton *digitButton = buttonLayout->findChild<QPushButton *>(QString("button%1").arg(i));
         QObject::connect(digitButton, &QPushButton::clicked, updateDisplayLambda);
     }
     QObject::connect(buttonDecimal, &QPushButton::clicked, updateDisplayLambda);
@@ -94,7 +91,7 @@ int main(int argc, char *argv[]) {
         myCalculator.setSecondOperand(myCalculator.getCurrentInput().toDouble());
         try {
             double result = myCalculator.calculateResult();
-            inputDisplay.setText(QString::number(result));
+            inputDisplay->setText(QString::number(result));
         } catch (const std::logic_error &e) {
             handleError(QString::fromStdString(e.what()), &mainWindow);
         }
@@ -104,10 +101,10 @@ int main(int argc, char *argv[]) {
     // Handle the clear button
     QObject::connect(buttonClear, &QPushButton::clicked, [&]() {
         myCalculator.clear();
-        inputDisplay.clear();
+        inputDisplay->clear();
     });
 
-    mainWindow.setLayout(&mainLayout);
+    mainWindow.setLayout(mainLayout);
     mainWindow.show();
 
     return app.exec();


### PR DESCRIPTION
## Summary
- allocate main window layout objects on the heap so Qt parent manages them
- update all layout and input widget references

## Testing
- `qmake tests.pro`
- `make`
- `QT_QPA_PLATFORM=offscreen make check`

------
https://chatgpt.com/codex/tasks/task_b_6843fda8735c8324b87f6e403c1c3c79